### PR TITLE
GLIBCXX workaround

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: macOS-latest, bioc: 'release', curlConfigPath: '/usr/bin/'}
-        - { os: ubuntu-latest, bioc: 'release', image: "bioconductor/bioconductor_docker:RELEASE_3_15", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+        - { os: macOS-latest, bioc: 'devel', curlConfigPath: '/usr/bin/'}
+        - { os: ubuntu-latest, bioc: 'devel', image: "bioconductor/bioconductor_docker:devel", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sketchR
-Version: 0.1.5
+Version: 0.1.6
 Title: An R interface for python subsampling/sketching algorithms
 Authors@R: c(
     person("Charlotte", "Soneson", email = "charlottesoneson@gmail.com",
@@ -11,7 +11,7 @@ Description: Provides an R interface for various subsampling algorithms
     implemented in python packages. Currently, interfaces to the geosketch 
     and scSampler python packages are implemented. 
 Imports:
-    basilisk,
+    basilisk (>= 1.9.5),
     Biobase,
     DelayedArray,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# sketchR 0.1.6
+
+* Add workaround for mismatching GLIBCXX versions
+
+# sketchR 0.1.5
+
+* Update scSampler to v1.0.2
+
 # sketchR 0.1.4
 
 * compareCompositionPlot() and hausdorffDistPlot() now return a ggplot object instead of a data.frame

--- a/R/geosketch.R
+++ b/R/geosketch.R
@@ -98,7 +98,7 @@ geosketch <- function(mat, N, replace = FALSE, k = "auto",
                        mat = mat, N = N, replace = replace, k = k,
                        alpha = alpha, seed = seed, max_iter = max_iter,
                        one_indexed = one_indexed, verbose = verbose,
-                       testload = "llvmlite")
+                       testload = "llvmlite.binding")
     idx
 }
 

--- a/R/geosketch.R
+++ b/R/geosketch.R
@@ -97,7 +97,8 @@ geosketch <- function(mat, N, replace = FALSE, k = "auto",
     idx <- basiliskRun(env = universalenv, fun = .run_geosketch,
                        mat = mat, N = N, replace = replace, k = k,
                        alpha = alpha, seed = seed, max_iter = max_iter,
-                       one_indexed = one_indexed, verbose = verbose)
+                       one_indexed = one_indexed, verbose = verbose,
+                       testload = "llvmlite")
     idx
 }
 

--- a/R/scsampler.R
+++ b/R/scsampler.R
@@ -76,7 +76,8 @@ scsampler <- function(mat, N, random_split = 1, seed = 0) {
     ## --------------------------------------------------------------------- ##
     idx <- basiliskRun(env = universalenv, fun = .run_scsampler,
                        mat = mat, n_obs = N, random_state = seed,
-                       random_split = random_split)
+                       random_split = random_split,
+                       testload = "llvmlite")
     idx
 }
 

--- a/R/scsampler.R
+++ b/R/scsampler.R
@@ -77,7 +77,7 @@ scsampler <- function(mat, N, random_split = 1, seed = 0) {
     idx <- basiliskRun(env = universalenv, fun = .run_scsampler,
                        mat = mat, n_obs = N, random_state = seed,
                        random_split = random_split,
-                       testload = "llvmlite")
+                       testload = "llvmlite.binding")
     idx
 }
 


### PR DESCRIPTION
This PR adds a workaround for the error appearing in the GHA (caused by mismatching GLIBCXX versions, see link to explanation in commit). The workaround requires `basilisk` 1.9.5, so I suggest we hold off with the merging until Bioc 3.16 is out.