### PR TITLE
Fix vignette and GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,9 +45,9 @@ jobs:
         uses: r-lib/actions/setup-pandoc@v2
         if: matrix.config.image == null
 
-      - name: Unset DYLD_FALLBACK_LIBRARY_PATH
-        if: runner.os == 'macOS'
-        run: unset DYLD_FALLBACK_LIBRARY_PATH
+      # - name: Unset DYLD_FALLBACK_LIBRARY_PATH
+      #   if: runner.os == 'macOS'
+      #   run: unset DYLD_FALLBACK_LIBRARY_PATH
 
       - name: Install remotes
         run: |
@@ -109,6 +109,8 @@ jobs:
         shell: Rscript {0}
 
       - name: Build, Install, Check
+        env:
+            DYLD_FALLBACK_LIBRARY_PATH:
         uses: grimbough/bioc-actions/build-install-check@v1
 
 #      - name: Run BiocCheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,9 +45,9 @@ jobs:
         uses: r-lib/actions/setup-pandoc@v2
         if: matrix.config.image == null
 
-      # - name: Unset DYLD_FALLBACK_LIBRARY_PATH
-      #   if: runner.os == 'macOS'
-      #   run: unset DYLD_FALLBACK_LIBRARY_PATH
+      - name: Unset DYLD_FALLBACK_LIBRARY_PATH
+        if: runner.os == 'macOS'
+        run: unset DYLD_FALLBACK_LIBRARY_PATH
 
       - name: Install remotes
         run: |
@@ -109,8 +109,6 @@ jobs:
         shell: Rscript {0}
 
       - name: Build, Install, Check
-        env:
-            DYLD_FALLBACK_LIBRARY_PATH:
         uses: grimbough/bioc-actions/build-install-check@v1
 
 #      - name: Run BiocCheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -45,6 +45,10 @@ jobs:
         uses: r-lib/actions/setup-pandoc@v2
         if: matrix.config.image == null
 
+      - name: Unset DYLD_FALLBACK_LIBRARY_PATH
+        if: runner.os == 'macOS'
+        run: unset DYLD_FALLBACK_LIBRARY_PATH
+
       - name: Install remotes
         run: |
           install.packages('remotes')

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -108,6 +108,10 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
+      - name: Check DYLD_FALLBACK_LIBRARY_PATH
+        if: runner.os == 'macOS'
+        run: echo $DYLD_FALLBACK_LIBRARY_PATH
+
       - name: Build, Install, Check
         uses: grimbough/bioc-actions/build-install-check@v1
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,10 +33,11 @@ Suggests:
     celldex,
     cowplot,
     SummarizedExperiment,
+    beachmat.hdf5,
     BiocStyle,
     BiocManager,
     SingleCellExperiment
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.0
 Encoding: UTF-8
 StagedInstall: no
 Config/testthat/edition: 3

--- a/vignettes/sketchR.Rmd
+++ b/vignettes/sketchR.Rmd
@@ -46,6 +46,7 @@ suppressPackageStartupMessages({
     library(cowplot)
     library(SummarizedExperiment)
     library(SingleCellExperiment)
+    library(beachmat.hdf5)
 })
 ```
 
@@ -80,7 +81,6 @@ pbmc3k <- scater::runTSNE(pbmc3k, dimred = "PCA")
 
 ## Predict cell type labels
 ref_monaco <- celldex::MonacoImmuneData()
-assay(pbmc3k, "logcounts") <- as.matrix(assay(pbmc3k, "logcounts"))
 pred_monaco_main <- SingleR::SingleR(test = pbmc3k, ref = ref_monaco, 
                                      labels = ref_monaco$label.main)
 pbmc3k$labels_main <- pred_monaco_main$labels

--- a/vignettes/sketchR.Rmd
+++ b/vignettes/sketchR.Rmd
@@ -80,6 +80,7 @@ pbmc3k <- scater::runTSNE(pbmc3k, dimred = "PCA")
 
 ## Predict cell type labels
 ref_monaco <- celldex::MonacoImmuneData()
+assay(pbmc3k, "logcounts") <- as.matrix(assay(pbmc3k, "logcounts"))
 pred_monaco_main <- SingleR::SingleR(test = pbmc3k, ref = ref_monaco, 
                                      labels = ref_monaco$label.main)
 pbmc3k$labels_main <- pred_monaco_main$labels


### PR DESCRIPTION
- Import `beachmat.hdf5` to direct `tatami` to use native C++ bindings for HDF5 in the situation where it otherwise would try to call `extract_sparse_array()` on an `HDF5ArraySeed` (but no such method exists at the moment). 
- Fix an issue with installing conda on the GHA macOS runners by explicitly unsetting `DYLD_FALLBACK_LIBRARY_PATH`. This is included in newer versions of the conda installation shell script, but those are not (yet) used by `basilisk` (as they seem to not be supported on Windows). See https://github.com/conda/conda/issues/10582. 