### PR TITLE
Adapt GHA setup

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: macOS-latest, bioc: 'devel', miniconda: 'py311_23.11.0-2'}
-        - { os: macos-14, bioc: 'devel', miniconda: 'py311_23.11.0-2'}
-        - { os: windows-latest, bioc: 'devel'}
-        - { os: ubuntu-latest, bioc: 'devel', image: "bioconductor/bioconductor_docker:devel", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+        - { os: macOS-latest, bioc: 'devel', miniconda: 'py39_24.1.2-0'}
+        - { os: macos-14, bioc: 'devel', miniconda: 'py39_24.1.2-0'}
+        - { os: windows-latest, bioc: 'devel', miniconda: 'py39_4.12.0'}
+        - { os: ubuntu-latest, bioc: 'devel', miniconda: 'py39_24.1.2-0', image: "bioconductor/bioconductor_docker:devel", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,6 +82,7 @@ jobs:
         run: |
           brew install harfbuzz
           brew install fribidi
+          brew install openssl
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -68,8 +68,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-bioc-${{ matrix.config.bioc }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ runner.os }}-bioc-${{ matrix.config.bioc }}-
+          key: ${{ matrix.config.os }}-bioc-${{ matrix.config.bioc }}-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ matrix.config.os }}-bioc-${{ matrix.config.bioc }}-
 
       - name: Update apt-get
         if: runner.os == 'Linux'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: macOS-latest, bioc: 'devel'}
-        - { os: macos-14, bioc: 'devel'}
+        - { os: macOS-latest, bioc: 'devel', miniconda: 'py311_23.11.0-2'}
+        - { os: macos-14, bioc: 'devel', miniconda: 'py311_23.11.0-2'}
         - { os: windows-latest, bioc: 'devel'}
         - { os: ubuntu-latest, bioc: 'devel', image: "bioconductor/bioconductor_docker:devel", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
@@ -31,6 +31,7 @@ jobs:
       CRAN: ${{ matrix.config.cran }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      BASILISK_MINICONDA_VERSION: ${{ matrix.config.miniconda }}
 
     steps:
       - name: Check out repo

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: macOS-latest, bioc: 'devel', miniconda: 'py39_24.1.2-0'}
-        - { os: macos-14, bioc: 'devel', miniconda: 'py39_24.1.2-0'}
+        - { os: macOS-latest, bioc: 'devel', miniconda: 'py39_22.11.1-1'}
+        - { os: macos-14, bioc: 'devel', miniconda: 'py39_22.11.1-1'}
         - { os: windows-latest, bioc: 'devel', miniconda: 'py39_4.12.0'}
-        - { os: ubuntu-latest, bioc: 'devel', miniconda: 'py39_24.1.2-0', image: "bioconductor/bioconductor_docker:devel", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
+        - { os: ubuntu-latest, bioc: 'devel', miniconda: 'py39_4.12.0', image: "bioconductor/bioconductor_docker:devel", cran: "https://demo.rstudiopm.com/all/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
+        ## For macOS, explicitly use newer miniconda (where DYLD_FALLBACK_LIBRARY_PATH is unset
+        ## in the installation script) than the one used by basilisk
         - { os: macOS-latest, bioc: 'devel', miniconda: 'py39_22.11.1-1'}
         - { os: macos-14, bioc: 'devel', miniconda: 'py39_22.11.1-1'}
         - { os: windows-latest, bioc: 'devel', miniconda: 'py39_4.12.0'}
@@ -84,7 +86,22 @@ jobs:
           brew install fribidi
           brew install openssl
 
+      ## make sure that crypto is found (suggestion from https://github.com/schienstockd/cecelia)
+      - name: Install dependencies (macos-14)
+        if: matrix.config.os == 'macos-14'
+        env:
+            LIBRARY_PATH: '/opt/homebrew/lib'
+            LDFLAGS: '-L/opt/homebrew/lib'
+            CPPFLAGS: '-I/opt/homebrew/include'
+        run: |
+          local_deps <- remotes::local_package_deps(dependencies = TRUE)
+          deps <- remotes::dev_package_deps(dependencies = TRUE, repos = BiocManager::repositories())
+          BiocManager::install(local_deps[local_deps %in% deps$package[deps$diff != 0]], Ncpu = 2L)
+          remotes::install_cran('rcmdcheck', Ncpu = 2L)
+        shell: Rscript {0}
+
       - name: Install dependencies
+        if: matrix.config.os != 'macos-14'
         run: |
           local_deps <- remotes::local_package_deps(dependencies = TRUE)
           deps <- remotes::dev_package_deps(dependencies = TRUE, repos = BiocManager::repositories())


### PR DESCRIPTION
Adapt GitHub Actions setup to allow the package to be tested on all platforms: 
- explicitly use a newer miniconda (where `DYLD_FALLBACK_LIBRARY_PATH` is unset so that conda can be installed, but where pinned package versions can still be resolved) on macOS
- make sure that the crypto library can be found on macos-14